### PR TITLE
Fixed name of migration file when copying and publish

### DIFF
--- a/src/ReviewRateableServiceProvider.php
+++ b/src/ReviewRateableServiceProvider.php
@@ -15,7 +15,7 @@ class ReviewRateableServiceProvider extends ServiceProvider
     {
         $timestamp = date('Y_m_d_His', time());
         $this->publishes([
-            __DIR__.'/../database/migrations/create_reviews_table.php.stub' => $this->app->databasePath()."/migrations/{$timestamp}_create_reviews_table.php",
+            __DIR__.'/../database/migrations/create_ratings_table.php.stub' => $this->app->databasePath()."/migrations/{$timestamp}_create_ratings_table.php",
         ], 'migrations');
     }
 


### PR DESCRIPTION
Naming was wrong. Had renamed locally. Fixed issue.