### PR TITLE
Updates aggregate functions to return scalar values

### DIFF
--- a/src/Contracts/ReviewRateable.php
+++ b/src/Contracts/ReviewRateable.php
@@ -13,26 +13,26 @@ interface ReviewRateable
 
     /**
      *
-     * @return mix
+     * @return double
      */
-    public function averageRating($round= null);
+    public function averageRating($round = null);
 
     /**
      *
-     * @return mix
+     * @return int
      */
     public function countRating();
 
     /**
      *
-     * @return mix
+     * @return double
      */
     public function sumRating();
 
     /**
      * @param $max
      *
-     * @return mix
+     * @return double
      */
     public function ratingPercent($max = 5);
 

--- a/src/Traits/ReviewRateable.php
+++ b/src/Traits/ReviewRateable.php
@@ -17,52 +17,60 @@ trait ReviewRateable
 
     /**
      *
-     * @return mix
+     * @return double
      */
-    public function averageRating($round= null)
+    public function averageRating($round = null)
     {
-      if ($round) {
-            return $this->ratings()
-              ->selectRaw('ROUND(AVG(rating), '.$round.') as averageReviewRateable')
-              ->pluck('averageReviewRateable');
+        $avgExpression = null;
+        if ($round) {
+            $avgExpression = 'ROUND(AVG(rating), ' . $round . ') as averageReviewRateable';
+        } else {
+            $avgExpression = 'AVG(rating) as averageReviewRateable';
         }
 
         return $this->ratings()
-            ->selectRaw('AVG(rating) as averageReviewRateable')
-            ->pluck('averageReviewRateable');
+            ->selectRaw($avgExpression)
+            ->get()
+            ->first()
+            ->averageReviewRateable;
     }
 
     /**
      *
-     * @return mix
+     * @return int
      */
-    public function countRating(){
-      return $this->ratings()
-          ->selectRaw('count(rating) as countReviewRateable')
-          ->pluck('countReviewRateable');
+    public function countRating()
+    {
+        return $this->ratings()
+            ->selectRaw('count(rating) as countReviewRateable')
+            ->get()
+            ->first()
+            ->countReviewRateable;
     }
 
     /**
      *
-     * @return mix
+     * @return double
      */
     public function sumRating()
     {
         return $this->ratings()
             ->selectRaw('SUM(rating) as sumReviewRateable')
-            ->pluck('sumReviewRateable');
+            ->get()
+            ->first()
+            ->sumReviewRateable;
     }
 
     /**
      * @param $max
      *
-     * @return mix
+     * @return double
      */
     public function ratingPercent($max = 5)
     {
         $ratings = $this->ratings();
         $quantity = $ratings->count();
-        $total = $ratings->selectRaw('SUM(rating) as total')->pluck('total');
+        $total = $ratings->selectRaw('SUM(rating) as total')->get()->first()->total;
         return ($quantity * $max) > 0 ? $total / (($quantity * $max) / 100) : 0;
     }
 


### PR DESCRIPTION
In laravel versions >= 5.1 the eloquent pluck method returns a collection instead of a scalar.

So this fix updates the `averageRating`, `countRating`, `sumRating` and `ratingPercent` methods of the `ReviewRateable` trait to return the actual values instead of the collection.